### PR TITLE
商品詳細表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,6 +35,6 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :information, :user_id, :price, :category_id, :state_id, :cost_id, :place_id,
-                                 :day_id, :image, :id).merge(user_id: current_user.id)
+                                 :day_id, :image).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,7 +10,9 @@ class ItemsController < ApplicationController
   end
 
  
-
+  def show
+    @item = Item.find(params[:id])
+  end
 
 
 
@@ -33,6 +35,6 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :information, :user_id, :price, :category_id, :state_id, :cost_id, :place_id,
-                                 :day_id, :image).merge(user_id: current_user.id)
+                                 :day_id, :image, :id).merge(user_id: current_user.id)
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -124,9 +124,12 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "new_item_path", class: "subtitle" %>
     <ul class='item-lists'>
+
+    
        <% @items.each do |item| %>
         <div class='item-info'>
-        <%= image_tag item.image.variant(resize: '300x300'), class: 'item-image' if item.image.attached? %>
+        <%= link_to item_path (item.id) do %>
+        <%= image_tag item.image.variant(resize: '400x400'), class: 'item-image' if item.image.attached? %>
           <h3 class='item-name'>
             <%= item.name %>
           </h3>
@@ -134,8 +137,9 @@
             <span><%= item.price %>円<br><%= item.cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
+              <span class='star-count'>0</span>    
+          </div>
+       <% end %> 
           </div>
         </div>
         <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,25 +16,27 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.cost.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? %>
+    <% if current_user.id == @item.user.id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+    <% end %>  
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% unless current_user.id == @item.user.id %>
+    <%# unless @items.empty? %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# end %>
+    <% end %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,27 +45,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.state.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.place.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,22 +24,17 @@
     </div>
 
     <% if user_signed_in? %>
-    <% if current_user.id == @item.user.id %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <% end %>  
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% unless current_user.id == @item.user.id %>
-    <%# unless @items.empty? %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-    <%# end %>
-    <% end %>
+     <% if current_user.id == @item.user.id %>
+       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+       <p class="or-text">or</p>
+       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+     <% else %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+     <% end %>
     <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.information %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -105,7 +100,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
 
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
What
商品詳細表示機能実装

Why
ホームにある、出品されている商品の一覧から、各商品の詳細ページに飛べるようにするため。
購入機能は未実施、soldoutは消していない。

ページ遷移
https://gyazo.com/d7202ee9f750408b3caea434fe4b5ed4

ログインユーザーが自身の商品を表示している。
編集、削除ボタンが表示される
https://gyazo.com/a4d4a4b9e3d510f689b851b9c3212714
ログインユーザーが他者の商品を表示している
購入ボタンが表示されている
https://gyazo.com/7325caa579448ad2c835a01858871d4c

ログインしていないユーザーが商品ページを閲覧している
購入、編集、削除ボタンは表示されない
https://gyazo.com/13118727a1350b39308b8bff4cec9464