### PR TITLE
basic認証実証

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
@@ -10,4 +11,11 @@ class ApplicationController < ActionController::Base
                                       keys: %i[nickname password lastname firstname
                                                katakanalastname katakanafirstname birthday])
   end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
+
 end


### PR DESCRIPTION
What
Basic認証の導入

Why
ページを開いた際に、指定のパスワードを入力
しなければアクセスできないようにするため。